### PR TITLE
routed placeholder pages with react-router-dom

### DIFF
--- a/ourexp-ui/package-lock.json
+++ b/ourexp-ui/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.27.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -977,6 +978,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
+      "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3635,6 +3645,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
+      "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
+      "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.20.0",
+        "react-router": "6.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/ourexp-ui/package.json
+++ b/ourexp-ui/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.27.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",

--- a/ourexp-ui/src/App.jsx
+++ b/ourexp-ui/src/App.jsx
@@ -1,33 +1,30 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import Entries from './pages/Entries';
+import Home from './pages/Home';
+import Submit from './pages/Submit';
 
 function App() {
-  const [count, setCount] = useState(0)
+
+  const router = createBrowserRouter([
+    {
+      path: "/",
+      element: <Home />,
+    },
+    {
+      path: "/entries",
+      element: <Entries />,
+    },
+    {
+      path: "/submit",
+      element: <Submit />,
+    }
+  ]);
+
 
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <RouterProvider router={router} />
     </>
   )
 }

--- a/ourexp-ui/src/pages/Entries.jsx
+++ b/ourexp-ui/src/pages/Entries.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function Entries() {
+  return (
+    <div>Hello, entries!</div>
+  )
+}

--- a/ourexp-ui/src/pages/Home.jsx
+++ b/ourexp-ui/src/pages/Home.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function Home() {
+  return (
+    <div>Hello, home!</div>
+  )
+}

--- a/ourexp-ui/src/pages/Submit.jsx
+++ b/ourexp-ui/src/pages/Submit.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function Submit() {
+  return (
+    <div>Hello, submission form!</div>
+  )
+}


### PR DESCRIPTION
In this branch, I:
- Installed react-router-dom
- Routed placeholder pages for home, submission form, and entries

To test it:
- From the UI directory, run `npm install`
- Run `npm run dev` and press o
- Use the navigation bar to view localhost:5173, localhost:5173/submit, and localhost:5173/entries