### PR TITLE
removed cascadetype merge from feelings field in Entry class

### DIFF
--- a/ourexp-api/src/main/java/com/example/ourexp/models/Entry.java
+++ b/ourexp-api/src/main/java/com/example/ourexp/models/Entry.java
@@ -13,7 +13,7 @@ public class Entry extends AbstractEntity {
     private String title;
     private LocalDateTime time = LocalDateTime.now();
 
-    @ManyToMany(cascade = { CascadeType.MERGE })
+    @ManyToMany
     @JoinTable(
             name = "Entry_Feeling",
             joinColumns = { @JoinColumn(name = "entry_id") },


### PR DESCRIPTION
On editing entries, feelings were also being updated in the database. I removed `CascadeType.MERGE` from the feelings field in the Entry class, which corrected this behavior. Creating, reading, updating, and deleting now perform as expected.